### PR TITLE
support for regular expressions in package.json config

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,13 @@ var fs = require('fs');
 var path = require('path');
 var minify = require('html-minifier').minify;
 
+var regexps = [
+    'ignoreCustomComments',
+    'customAttrAssign',
+    'customAttrSurround',
+    'customAttrCollapse'
+];
+
 module.exports = function(file, opts) {
     if(/\.json$/.test(file)) return through();
 
@@ -17,6 +24,15 @@ module.exports = function(file, opts) {
         removeRedundantAttributes: true,
         removeEmptyAttributes: true
     };
+
+    Object.keys(opts.minify).forEach(function (key) {
+        if(~regexps.indexOf(key)) {
+          var value = opts.minify[key];
+            opts.minify[key] = Array.isArray(value) ?
+                value.map(asRegExp) :
+                asRegExp(value);
+        }
+    });
 
     var vars = {
         __filename: file,
@@ -61,5 +77,9 @@ module.exports = function(file, opts) {
             sm.emit('file', file);
             next();
         }
+    }
+
+    function asRegExp(val) {
+        return (val instanceof RegExp) ? val : new RegExp(val);
     }
 };

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "Tommy Leunen <tommy.leunen@gmail.com> (http://tommyleunen.com/)",
   "license": "MIT",
   "dependencies": {
-    "html-minifier": "^0.6.8",
+    "html-minifier": "^0.7.2",
     "quote-stream": "0.0.0",
     "static-module": "^1.0.0",
     "through2": "^0.6.2"


### PR DESCRIPTION
one of the features of `browserify` is being be able to provide the config for transforms in `package.json`

now, some of the options in `html-minifier` _require_ regular expressions:
- `ignoreCustomComments`
- `customAttrAssign`
- `customAttrSurround`
- `customAttrCollapse`

and to be able to leverage that power of `browserify`, aforementioned in package.json need to be strings

this PR converts those options as `RegExp`, if needed

so my `package.json` could look like:

``` json
{
  "browserify": {
    "transform": [
      [
        "brfs-htmlmin",
        {
          "minify": {
            "removeEmptyAttributes": false,
            "customAttrCollapse": "^ng\\-.+"
          }
        }
      ]
    ]
  }
}
```

---

also, bumped `html-minifier` to 0.7.2
